### PR TITLE
⚡Speed optimization:  db index on remoteCallId

### DIFF
--- a/prisma/migrations/20241208051426_index_on_remote_call_id/migration.sql
+++ b/prisma/migrations/20241208051426_index_on_remote_call_id/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "calls_remote_call_id_idx" ON "calls"("remote_call_id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,5 +22,6 @@ model Call {
   endedAt         DateTime? @db.Timestamp  @map("ended_at")
 //reconciledAt    DateTime @db.Timestamptz()  @map("reconciled_at")
 
+  @@index(remoteCallId)
   @@map("calls")
 }


### PR DESCRIPTION
## Summary
Adds index on the db on `calls.remote_call_id`, to reduce latency when receiving the webhook event to mark calls as ended.
## Testing
Nothing to test here, just an optimization