### PR TITLE
Fixes redis connection fin Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 release: bash ./heroku-scripts/release-tasks.sh
-web: node dist/src/main
-jobs: node dist/src/worker
+web: node dist/main
+jobs: node dist/worker

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 release: bash ./heroku-scripts/release-tasks.sh
-web: node --experimental-require-module dist/src/main
-jobs: --experimental-require-module node dist/src/worker
+web: node dist/src/main
+jobs: node dist/src/worker

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@nestjs/core": "^10.0.0",
         "@nestjs/platform-express": "^10.0.0",
         "@prisma/client": "^6.0.1",
+        "ioredis": "^5.4.1",
         "nestjs-pino": "^4.1.0",
         "pino-pretty": "^13.0.0",
         "reflect-metadata": "^0.2.0",
@@ -931,8 +932,7 @@
     "node_modules/@ioredis/commands": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
-      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==",
-      "peer": true
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -3741,7 +3741,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
       "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4120,7 +4119,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
       "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -5693,7 +5691,7 @@
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.4.1.tgz",
       "integrity": "sha512-2YZsvl7jopIa1gaePkeMtd9rAcSjOOjPtpcLlOeusyO+XH2SK5ZcT+UCrElPP+WVIInh2TzeI4XW9ENaSLVVHA==",
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
         "@ioredis/commands": "^1.1.1",
         "cluster-key-slot": "^1.1.0",
@@ -6917,14 +6915,12 @@
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
-      "peer": true
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
     },
     "node_modules/lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
-      "peer": true
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -8163,7 +8159,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
       "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -8172,7 +8167,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
       "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
-      "peer": true,
       "dependencies": {
         "redis-errors": "^1.0.0"
       },
@@ -8811,8 +8805,7 @@
     "node_modules/standard-as-callback": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
-      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
-      "peer": true
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
     "node_modules/statuses": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
     "@prisma/client": "^6.0.1",
+    "ioredis": "^5.4.1",
     "nestjs-pino": "^4.1.0",
     "pino-pretty": "^13.0.0",
     "reflect-metadata": "^0.2.0",

--- a/src/app/libraries/bullmq/bullmq.module.ts
+++ b/src/app/libraries/bullmq/bullmq.module.ts
@@ -1,20 +1,25 @@
 import { Module } from '@nestjs/common';
 import { BullModule } from '@nestjs/bullmq';
 import { CALLS_WEBHOOKS_QUEUE } from 'src/app/shared/constants';
+import { Redis } from 'ioredis';
 
+const redisOptions =
+  process.env.NODE_ENV === 'development'
+    ? {
+        host: 'localhost',
+        port: 6379,
+      }
+    : new Redis(process.env.REDIS_URL as string, {
+        maxRetriesPerRequest: null,
+        tls: { rejectUnauthorized: process.env.NODE_ENV === 'development' },
+      });
 @Module({
   imports: [
     BullModule.forRootAsync({
       useFactory: () => ({
         connection: {
           url: process.env.REDIS_URL ?? 'redis://localhost:6379',
-          redis: {
-            checkServerIdentity: () => undefined, //bypass hostname validation
-            tls:
-              process.env.NODE_ENV === 'development'
-                ? undefined
-                : { rejectUnauthorized: false },
-          },
+          redisOptions,
         },
       }),
     }),

--- a/src/app/libraries/bullmq/bullmq.module.ts
+++ b/src/app/libraries/bullmq/bullmq.module.ts
@@ -8,7 +8,7 @@ import { CALLS_WEBHOOKS_QUEUE } from 'src/app/shared/constants';
       useFactory: () => ({
         connection: {
           url: process.env.REDIS_URL ?? 'redis://localhost:6379',
-          redisOptions: {
+          redis: {
             tls:
               process.env.NODE_ENV === 'development'
                 ? undefined

--- a/src/app/libraries/bullmq/bullmq.module.ts
+++ b/src/app/libraries/bullmq/bullmq.module.ts
@@ -9,6 +9,7 @@ import { CALLS_WEBHOOKS_QUEUE } from 'src/app/shared/constants';
         connection: {
           url: process.env.REDIS_URL ?? 'redis://localhost:6379',
           redis: {
+            checkServerIdentity: () => undefined, //bypass hostname validation
             tls:
               process.env.NODE_ENV === 'development'
                 ? undefined

--- a/src/app/libraries/bullmq/bullmq.module.ts
+++ b/src/app/libraries/bullmq/bullmq.module.ts
@@ -13,14 +13,12 @@ const redisOptions =
         maxRetriesPerRequest: null,
         tls: { rejectUnauthorized: process.env.NODE_ENV === 'development' },
       });
+
 @Module({
   imports: [
     BullModule.forRootAsync({
       useFactory: () => ({
-        connection: {
-          url: process.env.REDIS_URL ?? 'redis://localhost:6379',
-          redisOptions,
-        },
+        connection: redisOptions,
       }),
     }),
     BullModule.registerQueue({


### PR DESCRIPTION
## Summary
A couple of things:
1. Removes `--experimental-require-module` flag on procfile that starts web and worker servers. Since node v22 it's not needed anymore.
2. Fixes redis connection for Heroku, since the app was crashing with a SELF_SIGNED_CERT error. Did so by installing `ioredis` and using an instance of that class as a connection object that is passed to the `BullMQModule`

## Testing
Hit the `POST /events` in prod normally, and make sure a successful response is returned (refer to #1 )